### PR TITLE
fix(auth): persist PKCE state in database instead of in-memory dict

### DIFF
--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -28,10 +28,10 @@ auth_router = APIRouter()
 
 
 @auth_router.get("/auth/github")
-def github_login():
+def github_login(db: Annotated[Session, Depends(get_db)]):
     state = generate_state()
     verifier, challenge = generate_pkce_pair()
-    store_pkce(state, verifier)
+    store_pkce(state, verifier, db)
 
     params = {
         "client_id": settings.GITHUB_CLIENT_ID_WEB,
@@ -66,7 +66,7 @@ async def github_callback(
     else:
         client_id = settings.GITHUB_CLIENT_ID_WEB
         client_secret = settings.GITHUB_CLIENT_SECRET_WEB
-        stored_verifier = pop_pkce_verifier(state)
+        stored_verifier = pop_pkce_verifier(state, db)
         if stored_verifier:
             code_verifier = stored_verifier
 

--- a/app/auth/service.py
+++ b/app/auth/service.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..config import settings
-from ..models import RefreshToken, Role, User
+from ..models import OAuthState, RefreshToken, Role, User
 from ..utils import utcnow
 
 ACCESS_TOKEN_EXPIRE_MINUTES = 3
@@ -19,7 +19,7 @@ REFRESH_TOKEN_EXPIRE_MINUTES = 5
 GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
 GITHUB_USER_URL = "https://api.github.com/user"
 
-pkce_store: dict[str, str] = {}
+PKCE_EXPIRE_MINUTES = 10
 
 TEST_USERS = {
     "test_code": {
@@ -107,12 +107,32 @@ def generate_state() -> str:
     return secrets.token_urlsafe(16)
 
 
-def store_pkce(state: str, verifier: str):
-    pkce_store[state] = verifier
+def store_pkce(state: str, verifier: str, db: Session):
+    oauth_state = OAuthState(
+        state=state,
+        code_verifier=verifier,
+        expires_at=utcnow() + timedelta(minutes=PKCE_EXPIRE_MINUTES),
+    )
+    db.add(oauth_state)
+    db.commit()
 
 
-def pop_pkce_verifier(state: str) -> str | None:
-    return pkce_store.pop(state, None)
+def pop_pkce_verifier(state: str, db: Session) -> str | None:
+    row = db.execute(
+        select(OAuthState).where(
+            OAuthState.state == state,
+            OAuthState.used.is_(False),
+        )
+    ).scalar_one_or_none()
+    if not row:
+        return None
+    if row.expires_at < utcnow():
+        row.used = True
+        db.commit()
+        return None
+    row.used = True
+    db.commit()
+    return row.code_verifier
 
 
 async def exchange_github_code(

--- a/app/models.py
+++ b/app/models.py
@@ -80,6 +80,18 @@ class RefreshToken(Base):
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
 
+class OAuthState(Base):
+    __tablename__ = "oauth_states"
+
+    id: Mapped[str] = mapped_column(
+        default=lambda: str(uuid6.uuid7()), primary_key=True
+    )
+    state: Mapped[str] = mapped_column(String, unique=True, index=True)
+    code_verifier: Mapped[str] = mapped_column(String)
+    used: Mapped[bool] = mapped_column(default=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+
 class ProfileResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
The in-memory pkce_store dict loses state on serverless cold starts and across multiple instances. Move PKCE storage to a new oauth_states table so code_verifier survives restarts and works in distributed deployments.

Changes:
- Add OAuthState model (state, code_verifier, used, expires_at)
- Update store_pkce/pop_pkce_verifier to use DB with expiry checks
- Pass db session from router to PKCE functions